### PR TITLE
Add the `applications.gecko` key to `manifest.json`

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -33,5 +33,13 @@
     "16": "images/icon_16.png",
     "48": "images/icon_48.png",
     "128": "images/icon_128.png"
+  },
+  "applications": 
+  {
+    "gecko": 
+    {
+      "id": "firefox@mega.co.nz",
+      "strict_min_version": "46.0"
+    }
   }
 }


### PR DESCRIPTION
The [`applications.gecko`](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/applications) contains the following values:
- `id`: This is the extension ID of the legacy Firefox extension, this is needed so that [AMO](https://addons.mozilla.org) knows that we are updating the legacy extension to a WebExtension.
- `strict_min_version`: This is the minimum Firefox version that supports all the APIs that are in use by this extension. (This is the Firefox equivalent of Chrome’s [`minimum_chrome_version`](https://developer.chrome.com/extensions/manifest/minimum_chrome_version))

### See also:
- https://developer.mozilla.org/Add-ons/WebExtensions/Porting_a_Google_Chrome_extension
- https://developer.mozilla.org/Add-ons/WebExtensions/Porting_a_legacy_Firefox_add-on
- https://developer.mozilla.org/Add-ons/WebExtensions/WebExtensions_and_the_Add-on_ID
- https://developer.mozilla.org/Add-ons/WebExtensions/Publishing_your_WebExtension
- https://developer.mozilla.org/Add-ons/WebExtensions/Browser_support_for_JavaScript_APIs
  (For determining the minimum supported Firefox version)

Since this addon has been published as a [legacy extension](https://github.com/meganz/firefox-extension) in the past, it is required that the Add-on ID is set to what it was in the legacy version, so that Firefox can update the installed extension properly.

---

First step to resolving meganz/firefox-extension#3